### PR TITLE
Add basic junit format support

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var path = require('path');
 var updateNotifier = require('update-notifier');
 
 var base = require('./lib/base');
+var junit = require('./lib/junit');
 var re = require('./lib/re');
 
 var A = base.A;
@@ -118,6 +119,12 @@ var logFormatErrors = function(errors, file) {
 		console.log('File:'.blackBG + ' ' + file.underline);
 	}
 
+	errors = errors.map(
+		function(error) {
+			return error.err;
+		}
+	);
+
 	if (errors.length) {
 		errors.sort(sortErrors);
 
@@ -203,6 +210,10 @@ series.push(
 		}
 	}
 );
+
+if (argv.junit) {
+	series.push(junit.generate);
+}
 
 var callback = function() {};
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -53,8 +53,14 @@ var argv = optimist.argv;
 
 var fileErrors = {};
 
-var trackErr = function(err, file) {
+var testStats = {
+	failures: 0
+};
+
+var trackErr = function(err, file, type) {
 	var errors = fileErrors[file];
+
+	testStats.failures++;
 
 	if (!errors) {
 		errors = [];
@@ -62,7 +68,12 @@ var trackErr = function(err, file) {
 		fileErrors[file] = errors;
 	}
 
-	errors.push(err);
+	errors.push(
+		{
+			err: err,
+			type: type
+		}
+	);
 };
 
 var REGEX_SUB = /\{\s*([^|}]+?)\s*(?:\|([^}]*))?\s*\}/g;
@@ -101,5 +112,6 @@ module.exports = {
 	iterateLines: iterateLines,
 	optimist: optimist,
 	sub: sub,
+	testStats: testStats,
 	trackErr: trackErr
 };

--- a/lib/junit.js
+++ b/lib/junit.js
@@ -1,0 +1,64 @@
+var _ = require('underscore');
+var cli = require('cli');
+var fs = require('fs');
+var mustache = require('mustache');
+
+var base = require('./base');
+
+var A = base.A;
+var argv = base.argv;
+var fileErrors = base.fileErrors;
+var testStats = base.testStats;
+
+module.exports = {
+	generate: function(cb) {
+		fs.readFile(__dirname + '/junit_report.tpl', { encoding: 'utf-8' },
+			function(err, tpl) {
+				var result = {
+					files: [],
+					stats: testStats
+				};
+
+				A.Object.each(
+					fileErrors,
+					function(fileErrors, fileName) {
+						var errors = [];
+
+						A.Object.each(
+							_.groupBy(fileErrors, 'type'),
+							function(violations, violationType) {
+								errors.push(
+									{
+										testName: violationType,
+										failure: {
+											msg: violationType,
+											stack: violations.map(
+												function(violation) {
+													return violation.err;
+												}
+											).join('\n')
+										}
+									}
+								);
+							}
+						);
+
+						var fileResult = {
+							errors: errors,
+							file: fileName,
+							stats: {
+								failures: fileErrors.length,
+							}
+						};
+
+						result.files.push(fileResult);
+					}
+				);
+
+				var xml = mustache.render(tpl, result);
+
+				fs.writeFile(argv.junit, xml, cb);
+			}
+		);
+	}
+}

--- a/lib/junit_report.tpl
+++ b/lib/junit_report.tpl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="" failures="{{stats.failures}}">
+	{{#files}}
+		<testsuite name="{{file}}" failures="{{stats.failures}}">
+			{{#errors}}
+				<testcase name="{{testName}}">
+					{{#failure}}
+						<failure type="failure" message="{{violationType}}">{{stack}}</failure>
+					{{/failure}}
+				</testcase>
+			{{/errors}}
+		</testsuite>
+	{{/files}}
+</testsuites>

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -12,7 +12,7 @@ var esLintFormatter = function(results, config) {
 		function(result, index) {
 			result.messages.forEach(
 				function(item, index) {
-					trackErr(sub('Line: {0} {1} ({2})', (item.line || 0), item.message, (item.ruleId || 'n/a')).warn, result.filePath);
+					trackErr(sub('Line: {0} {1} ({2})', (item.line || 0), item.message, (item.ruleId || 'n/a')).warn, result.filePath, (item.ruleId || item.message));
 				}
 			);
 		}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "colors": "^0.6.2",
     "eslint": "^0.7.4",
     "falafel": "^0.3.1",
+    "mustache": "^0.8.2",
     "optimist": "^0.6.1",
+    "underscore": "^1.7.0",
     "update-notifier": "^0.1.8",
     "yui": "^3.17.0-rc-1"
   }


### PR DESCRIPTION
Hey Nate!

I'm sending you a rough prototype to support generating valid junit output when using `check_sf --junit result.xml`

I've been working on this with @cgoncas over the week, and the idea is to enable `check_sf` in your pulls (or any frontend reviewer). Then, we should be able to present the results on github the same way they currently do for Brian on https://github.com/brianchandotcom/liferay-portal-ee/pull/7152#issuecomment-58438701. They are currently working on some issues with the Github plugin, but we already configured Cristina's task so you could check the results in here: http://ci.liferay.org.es/jenkins/job/cgoncas/266/testReport/

About the PR itself, feel free to work around it any way you see fit. In addition, I think we should work on exposing a consistent test results data that any report generator could use. For example, we could consider grouping all code that potentially calls `trackErr`. The way I see it, all those validations could be considered as rules. It also would help us keep track of how many rules are run against a given file. 

What do you think?

/cc @ipeychev, @mdelapenya
