### PR TITLE
docs: mark project as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> :warning: This project is effectively deprecated, superseded by [liferay-npm-scripts](https://github.com/liferay/liferay-npm-tools/tree/master/packages/liferay-npm-scripts), which acts as a wrapper around [Prettier](Prettier), [ESLint](ESLint), [stylelint](https://stylelint.io/), and some custom Liferay-specific rules.
+
 check-source-formatting
 =======================
 [![NPM version][npm-image]][npm-url]


### PR DESCRIPTION
The project lives on in spirit in the form of liferay-npm-tools and specifically the liferay-npm-scripts package:

https://github.com/liferay/liferay-npm-tools/tree/master/packages/liferay-npm-scripts

Will reach out to IT to actually archive the project because: (a) We aren't going to do any further development on this repo; (b) Even if we wanted to, @natecavanaugh is the sole owner of the NPM package and he's no longer with us; and (c) Archiving should stop new issues and PRs being created by bots (like [this one](https://github.com/liferay/liferay-frontend-source-formatter/pull/57)).